### PR TITLE
Fix: eureka build.gradle 수정

### DIFF
--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -17,6 +17,13 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+}
+
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"


### PR DESCRIPTION
## 📝 요약(Summary)
Redisson Config 수정 요청 드립니당


* What went wrong:
Execution failed for task ':order-service:compileJava'.
> Compilation failed; see the compiler output below.
  /Users/goorm/Desktop/study/profect-eatcloud-msa-v1/order-service/src/main/java/com/eatcloud/orderservice/config/RedissonConfig.java:3: error: package org.redisson does not exist
  import org.redisson.Redisson;
                     ^
  13 errors

* Try:
> Check your code and dependencies to fix the compilation error(s)
> Run with --scan to generate a Build Scan (Powered by Develocity).

BUILD FAILED in 20s
54 actionable tasks: 42 executed, 12 up-to-date


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 빌드 설정에 필요한 의존성을 추가했습니다: Spring Boot Starter, Spring Boot Starter Test, JUnit Platform Launcher, Spring Cloud Netflix Eureka Server Starter.
  - 사용자 기능이나 UI 변화는 없습니다. 서비스 동작에는 영향이 없으며, 개발·테스트 환경과 서비스 등록 서버 구성을 위한 기반을 정비해 안정성과 유지보수성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->